### PR TITLE
Add fallback logic for AntiForgeryToken, don't send a new AntiForgeryToken cookie on every request

### DIFF
--- a/source/CourtesyFlush/HtmlHelperExtension.cs
+++ b/source/CourtesyFlush/HtmlHelperExtension.cs
@@ -4,8 +4,6 @@ using CourtesyFlush;
 
 namespace System.Web.WebPages
 {
-    using System.Runtime.CompilerServices;
-
     public static class HtmlHelperExtension
     {
         public static MvcHtmlString FlushHead(this HtmlHelper html)

--- a/source/CourtesyFlush/HtmlHelperExtension.cs
+++ b/source/CourtesyFlush/HtmlHelperExtension.cs
@@ -4,6 +4,8 @@ using CourtesyFlush;
 
 namespace System.Web.WebPages
 {
+    using System.Runtime.CompilerServices;
+
     public static class HtmlHelperExtension
     {
         public static MvcHtmlString FlushHead(this HtmlHelper html)
@@ -26,6 +28,12 @@ namespace System.Web.WebPages
         public static MvcHtmlString FlushedAntiForgeryToken(this HtmlHelper html)
         {
             var token = html.ViewContext.HttpContext.Items[ControllerBaseExtension.FlushedAntiForgeryTokenKey] as string;
+
+            if (string.IsNullOrEmpty(token))
+            {
+                // Fall back to the standard AntiForgeryToken if no FlushedAntiForgeryToken exists.
+                return html.AntiForgeryToken();
+            }
 
             var tag = new TagBuilder("input");
             tag.Attributes["type"] = "hidden";


### PR DESCRIPTION
Adds logic to fall back to the built-in AntiForgeryToken hidden input if no FlushedAntiForgeryToken exists.
Avoids sending a new AntiForgeryToken cookie in the response if one already exists in the request.